### PR TITLE
cache checkcov with python gha

### DIFF
--- a/module-preview-action/action.yml
+++ b/module-preview-action/action.yml
@@ -42,10 +42,15 @@ runs:
         fetch-depth: 0
 
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: "pip"
+
     - name: Install Dependencies (Facets, Terraform, Checkov)
       shell: bash
       run: |
-        sudo apt-get install -y python3 python3-pip curl unzip jq git
+        sudo apt-get install -y curl unzip jq git
         curl -fsSL https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o terraform.zip
         unzip terraform.zip && mv terraform /usr/local/bin/ && rm terraform.zip
         pip install git+https://github.com/Facets-cloud/module-development-cli.git


### PR DESCRIPTION
instead of installing all pip dependencies each time, we can have that step install everything the first time then for subsequent runs load everything from the github actions cache