### PR TITLE
add versioning support for ftf cli

### DIFF
--- a/.github/workflows/test-module-preview.yaml
+++ b/.github/workflows/test-module-preview.yaml
@@ -26,4 +26,3 @@ jobs:
           #          token: ${{ secrets.FACETS_API_TOKEN }}
           dry-run: true
           all-modules: false
-          ftf_cli_version: 0.2.1

--- a/.github/workflows/test-module-preview.yaml
+++ b/.github/workflows/test-module-preview.yaml
@@ -26,3 +26,4 @@ jobs:
           #          token: ${{ secrets.FACETS_API_TOKEN }}
           dry-run: true
           all-modules: false
+          ftf_cli_version: "0.2.1"

--- a/.github/workflows/test-module-preview.yaml
+++ b/.github/workflows/test-module-preview.yaml
@@ -26,4 +26,4 @@ jobs:
           #          token: ${{ secrets.FACETS_API_TOKEN }}
           dry-run: true
           all-modules: false
-          ftf_cli_version: "0.2.1"
+          ftf_cli_version: 0.2.1

--- a/module-preview-action/README.md
+++ b/module-preview-action/README.md
@@ -22,6 +22,7 @@ jobs:
           control_plane_url: ${{ secrets.CONTROL_PLANE_URL }}
           username: ${{ secrets.FACETS_USERNAME }}
           token: ${{ secrets.FACETS_API_TOKEN }}
+          ftf_cli_version: 0.2.1 # Optional: Specify only if you want to use a specific version of the CLI
 ```
 
 ---
@@ -50,6 +51,7 @@ jobs:
           control_plane_url: ${{ secrets.CONTROL_PLANE_URL }}
           username: ${{ secrets.FACETS_USERNAME }}
           token: ${{ secrets.FACETS_API_TOKEN }}
+          ftf_cli_version: 0.2.1 # Optional: Specify only if you want to use a specific version of the CLI
 ```
 
 ## 🌱 Enabling Dry Run Mode

--- a/module-preview-action/action.yml
+++ b/module-preview-action/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "Whether the modules registered in preview mode are publishable or not. This is not required if publish is set to true."
     required: false
     default: "false"
+  ftf_cli_version:
+    description: "Facets CLI version to use"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -62,7 +66,13 @@ runs:
         sudo apt-get install -y python3 python3-pip curl unzip jq git
         curl -fsSL https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o terraform.zip
         unzip terraform.zip && mv terraform /usr/local/bin/ && rm terraform.zip
-        pip install git+https://github.com/Facets-cloud/module-development-cli.git
+        if [ -z "${{ inputs.ftf_cli_version }}" ]; then
+          echo "🔍 Installing latest version of ftf-cli..."
+          pip install ftf-cli
+        else
+          echo "🔍 Installing ftf-cli version ${{ inputs.ftf_cli_version }}..."
+          pip install ftf-cli==${{ inputs.ftf_cli_version }}
+        fi
 
     - name: Identify All Facets Modules (All Modules)
       if: inputs.all-modules == 'true'


### PR DESCRIPTION
This pr introduces support for using a specific version of ftf cli. The argument is optional for action and latest version is used if nothing is specified.

Testing:
- Run with version: https://github.com/Facets-cloud/github-actions/actions/runs/14988483133
- Run without version: https://github.com/Facets-cloud/github-actions/actions/runs/14988511207