### PR TITLE
fix(ci): test-module-ci workflow failed at startup (literal expression syntax in comment)

### DIFF
--- a/.github/workflows/test-module-ci.yaml
+++ b/.github/workflows/test-module-ci.yaml
@@ -40,8 +40,9 @@ jobs:
               run = s.get("run")
               if not run:
                   continue
-              # ${{ ... }} GitHub expressions are substituted before the shell runs;
-              # replace them with a token so shellcheck can parse the script.
+              # GitHub expression placeholders (dollar + double braces) are substituted
+              # before the shell runs; replace them with a token so shellcheck
+              # can parse the script.
               cleaned = re.sub(r"\$\{\{[^}]*\}\}", "GHEXPR", run)
               with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as f:
                   f.write("#!/usr/bin/env bash\n")


### PR DESCRIPTION
GitHub's expression scanner parses `${{ ... }}` inside `run:` comments too — the literal in the shellcheck step's comment made every run of this workflow fail at file-parse time (0s startup failures on every push since it was added; the action.yml validation never actually ran). Reworded the comment.

Verified by dispatching the workflow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)