### PR TITLE
fix(module-ci): exclude terraform-init'd .terraform/ deps from Trivy scan

### DIFF
--- a/module-ci-action/README.md
+++ b/module-ci-action/README.md
@@ -187,6 +187,10 @@ Plane. When a PR previews a module, the action registers the preview against the
 - **Validation gate (preview):** each module is first run through
   `raptor create iac-module -f <dir> --dry-run` (schema + Terraform + security checks)
   before the feature-branch registration.
+- **Security scan scope:** the Trivy scan (run by raptor) covers only the module's own
+  source. Raptor's validation runs `terraform init` first, which downloads remote module
+  dependencies into `.terraform/`; the action sets `TRIVY_SKIP_DIRS` so findings inside
+  those downloaded dependencies — code the module author never wrote — cannot fail CI.
 - **Provenance:** preview passes the PR head SHA explicitly because the PR checkout is a
   merge commit; publish relies on auto-detected provenance (on a push the checked-out
   `HEAD` *is* the pushed commit). The git remote URL is auto-detected from the work tree.

--- a/module-ci-action/action.yml
+++ b/module-ci-action/action.yml
@@ -256,6 +256,11 @@ runs:
         FACETS_USERNAME: ${{ inputs.username }}
         FACETS_TOKEN: ${{ inputs.token }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Trivy runs inside raptor's module validation, AFTER terraform init has
+        # vendored remote deps into .terraform/. Trivy reads flags from TRIVY_*
+        # env vars; skip the vendored tree so findings in dependency code the
+        # module author never wrote can't fail CI (issue #13).
+        TRIVY_SKIP_DIRS: "**/.terraform,**/.terraform/**"
       run: |
         set -uo pipefail
         FAILURES="${RUNNER_TEMP}/ci_failures"
@@ -352,6 +357,9 @@ runs:
         CONTROL_PLANE_URL: ${{ inputs.control_plane_url }}
         FACETS_USERNAME: ${{ inputs.username }}
         FACETS_TOKEN: ${{ inputs.token }}
+        # Same rationale as the preview step: keep raptor's Trivy scan out of
+        # terraform-init'd dependencies under .terraform/ (issue #13).
+        TRIVY_SKIP_DIRS: "**/.terraform,**/.terraform/**"
       run: |
         set -uo pipefail
         FAILURES="${RUNNER_TEMP}/ci_failures"


### PR DESCRIPTION
## Problem

Fixes #13.

`module-ci-action` calls `raptor create iac-module`, whose validation runs `terraform init` (vendoring remote module dependencies into `.terraform/modules/` — Terraform clones the whole source repo per module call) and then `trivy config --severity HIGH,CRITICAL <module dir>` with no `--skip-dirs`. Trivy therefore scans dependency code the module author never wrote and fails CI on findings they cannot fix (e.g. `KSV-0041`/`KSV-0056` against the `nginx-gateway-fabric` ClusterRole pulled in transitively via `facets-utility-modules`).

## Fix

Trivy binds every CLI flag to a `TRIVY_*` env var, and raptor invokes it as a child process that inherits the step environment. This PR sets

```yaml
TRIVY_SKIP_DIRS: "**/.terraform,**/.terraform/**"
```

on the **preview** and **publish** steps (the two that run raptor validation), scoping the scan to the module's own source. No raptor release is needed, and it works for any `raptor_version` / `trivy-version`. A root-cause PR adding `--skip-dirs` to raptor's own Trivy invocation is being raised separately in `Facets-cloud/raptor`; this env var stays as protection for older pinned raptor versions (the CLI flag will take precedence, with the same value).

## Verification

Repro per the issue, with Trivy **0.72.0** (the action's pinned default) and a scratch module sourcing `facets-utility-modules//name` + `//aws_irsa`, replicating raptor's exact invocation (`trivy config --format json --severity HIGH,CRITICAL --exit-code 0 --quiet .`):

| Run | HIGH/CRITICAL findings |
|---|---|
| baseline after `terraform init -backend=false` | **4** — all from `.terraform/modules/{name,irsa}/nginx_gateway_fabric/charts/...:templates/rbac.yaml` (2 checks × 2 vendored copies) |
| with `TRIVY_SKIP_DIRS='**/.terraform,**/.terraform/**'` | **0** |
| same, plus a seeded privileged-pod `bad.yaml` in the module's own source | **flagged** (`KSV-0014`, `KSV-0017`, `KSV-0118`) — the skip does not swallow real findings |

## Release

After merge: tag `v1.0.1` so `release.yml` moves the `v1` alias and consumers pinned to `@v1` pick this up on their next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)